### PR TITLE
VIM.rst mejorado

### DIFF
--- a/docs/editores/Vim.rst
+++ b/docs/editores/Vim.rst
@@ -16,8 +16,8 @@ Para poder usar la sintaxis de Latino en Vim, estos son los pasos a seguir:
 
 * Con el **programa cerrado**, nos vamos a donde tenemos el programa instalado **C:\\Program Files (x86)\\Vim\\vim80**
 * Una vez ahí pasamos a copiar y pegar las carpetas **ftdetect**, **syntax** y **Ultisnips** en la dirección anterior **vim80**
-* Aceptamos y confirmamos cuando se nos pregunte si queremos mezclar (**merge**) los archivos **y Listo!**
-* Ya podremos programar en Vim con sintaxis de Latino
+* Aceptamos y confirmamos cuando se nos pregunte si queremos mezclar (**merge**) los archivos.
+* **¡Y listo!** Ya podremos programar en Vim con la sintaxis de Latino
 
 .. figure:: ../_static/_media/editores-Instalacion/Vim/CopiarYPegar.png
    :figwidth: 100%

--- a/docs/editores/Vim.rst
+++ b/docs/editores/Vim.rst
@@ -8,16 +8,16 @@ Vim
 
 .. admonition:: Descargar
 
-   :download:`Descargar Vim <https://github.com/primitivorm/vim-latino>`
+   :download:`Descargar Latino-Vim <https://github.com/primitivorm/vim-latino>`
 
 **Sintaxis de Latino en Vim**
 
 Para poder usar la sintaxis de Latino en Vim, estos son los pasos a seguir:
 
-* Con el **programa cerrado**, nos vamos a donde tenemos el programa instalado **C:\Program Files (x86)\Vim\vim80**
+* Con el **programa cerrado**, nos vamos a donde tenemos el programa instalado **C:\\Program Files (x86)\\Vim\\vim80**
 * Una vez ahí pasamos a copiar y pegar las carpetas **ftdetect**, **syntax** y **Ultisnips** en la dirección anterior **vim80**
-* Aceptamos y confirmamos cuando se nos pregunte si queremos mezclar (**merge**) los archivos
-* **y Listo!** Ya podremos programar en Vim con sintaxis de Latino
+* Aceptamos y confirmamos cuando se nos pregunte si queremos mezclar (**merge**) los archivos **y Listo!**
+* Ya podremos programar en Vim con sintaxis de Latino
 
 .. figure:: ../_static/_media/editores-Instalacion/Vim/CopiarYPegar.png
    :figwidth: 100%


### PR DESCRIPTION
Tal como lo dije, XD.
La ruta de instalación de VIM se mostraba mal, lo he corregido. Para mostrar un '\\', hay que escribirlo 2 veces: '\\\\'.