### PR TITLE
la palabra "más" lleva tilde ...

### DIFF
--- a/docs/sintaxis/Variables.rst
+++ b/docs/sintaxis/Variables.rst
@@ -30,7 +30,7 @@ Declaración (creación) de variables
 ------------------------------------
 Las variables de Latino deben ser identificadas por un **nombre único**.
 
-Estos nombres pueden ser cortos (como X o Y) o pueden ser nombres mas descriptivos (como edad, nombre, valorTotal, etc.)
+Estos nombres pueden ser cortos (como X o Y) o pueden ser nombres más descriptivos (como edad, nombre, valorTotal, etc.)
 
 La regla general en Latino para crear nombres de variables son las siguientes:
 


### PR DESCRIPTION
En la frase "Estos nombres pueden ser cortos (como X o Y) o pueden ser nombres más descriptivos (como edad, nombre, valorTotal, etc.)", la palabra "más" lleva tilde porque funciona como un adverbio de cantidad, indicando una comparación o intensidad (en este caso, que son nombres más descriptivos).